### PR TITLE
update @aws-sdk/client-medialive to support elemental inference

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -40,6 +40,9 @@
     "test": {
       "options": {
         "passWithNoTests": true
+      },
+      "env": {
+        "NODE_OPTIONS": "--experimental-vm-modules"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-dynamodb": "^3.734.0",
         "@aws-sdk/client-iot": "^3.750.0",
         "@aws-sdk/client-iot-data-plane": "^3.744.0",
-        "@aws-sdk/client-medialive": "^3.734.0",
+        "@aws-sdk/client-medialive": "^3.1017.0",
         "@aws-sdk/client-mediapackage": "^3.734.0",
         "@aws-sdk/client-s3": "^3.758.0",
         "@aws-sdk/client-scheduler": "^3.758.0",
@@ -4139,380 +4139,423 @@
       }
     },
     "node_modules/@aws-sdk/client-medialive": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-medialive/-/client-medialive-3.744.0.tgz",
-      "integrity": "sha512-c/jAO6Q5MYnzIbIU6HEGwEo3FhFYZ1ljFbFuXbu2fZYuQcVME6ST5e0sKEKpIm3cKlOW22ynA3zl+p/Xujcb3Q==",
+      "version": "3.1017.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-medialive/-/client-medialive-3.1017.0.tgz",
+      "integrity": "sha512-UyRZSYgPruBRKq1wefgDcHqqnutYSsREgEd4pZdjgBQ1H4JT7/v1nYKt2TQ+478mp91ednRFIH8yGXS2HYZ43Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/credential-provider-node": "3.744.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.744.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.744.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.2",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-retry": "^4.0.4",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.4",
-        "@smithy/util-defaults-mode-node": "^4.0.4",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.2",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/client-sso": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.744.0.tgz",
-      "integrity": "sha512-mzJxPQ9mcnNY50pi7+pxB34/Dt7PUn0OgkashHdJPTnavoriLWvPcaQCG1NEVAtyzxNdowhpi4KjC+aN1EwAeA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.744.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.744.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.2",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-retry": "^4.0.4",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.4",
-        "@smithy/util-defaults-mode-node": "^4.0.4",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/core": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.744.0.tgz",
-      "integrity": "sha512-R0XLfDDq7MAXYyDf7tPb+m0R7gmzTRRDtPNQ5jvuq8dbkefph5gFMkxZ2zSx7dfTsfYHhBPuTBsQ0c5Xjal3Vg==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.744.0.tgz",
-      "integrity": "sha512-hyjC7xqzAeERorYYjhQG1ivcr1XlxgfBpa+r4pG29toFG60mACyVzaR7+og3kgzjRFAB7D1imMxPQyEvQ1QokA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
+      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.744.0.tgz",
-      "integrity": "sha512-k+P1Tl5ewBvVByR6hB726qFIzANgQVf2cY87hZ/e09pQYlH4bfBcyY16VJhkqYnKmv6HMdWxKHX7D8nwlc8Obg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
+      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.0.2",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.744.0.tgz",
-      "integrity": "sha512-hjEWgkF86tkvg8PIsDiB3KkTj7z8ZFGR0v0OLQYD47o17q1qfoMzZmg9wae3wXp9KzU+lZETo+8oMqX9a+7aVQ==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
+      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/credential-provider-env": "3.744.0",
-        "@aws-sdk/credential-provider-http": "3.744.0",
-        "@aws-sdk/credential-provider-process": "3.744.0",
-        "@aws-sdk/credential-provider-sso": "3.744.0",
-        "@aws-sdk/credential-provider-web-identity": "3.744.0",
-        "@aws-sdk/nested-clients": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-login": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.744.0.tgz",
-      "integrity": "sha512-4oUfRd6pe/VGmKoav17pPoOO0WP0L6YXmHqtJHSDmFUOAa+Vh0ZRljTj/yBdleRgdO6rOfdWqoGLFSFiAZDrsQ==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
+      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.744.0",
-        "@aws-sdk/credential-provider-http": "3.744.0",
-        "@aws-sdk/credential-provider-ini": "3.744.0",
-        "@aws-sdk/credential-provider-process": "3.744.0",
-        "@aws-sdk/credential-provider-sso": "3.744.0",
-        "@aws-sdk/credential-provider-web-identity": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-ini": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.744.0.tgz",
-      "integrity": "sha512-m0d/pDBIaiEAAxWXt/c79RHsKkUkyPOvF2SAMRddVhhOt1GFZI4ml+3f4drmAZfXldIyJmvJTJJqWluVPwTIqQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
+      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.744.0.tgz",
-      "integrity": "sha512-xdMufTZOvpbDoDPI2XLu0/Rg3qJ/txpS8IJR63NsCGotHJZ/ucLNKwTcGS40hllZB8qSHTlvmlOzElDahTtx/A==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
+      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.744.0",
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/token-providers": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/token-providers": "3.1015.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.744.0.tgz",
-      "integrity": "sha512-cNk93GZxORzqEojWfXdrPBF6a7Nu3LpPCWG5mV+lH2tbuGsmw6XhKkwpt7o+OiIP4tKCpHlvqOD8f1nmhe1KDA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
+      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/nested-clients": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.744.0.tgz",
-      "integrity": "sha512-ROUbDQHfVWiBHXd4m9E9mKj1Azby8XCs8RC8OCf9GVH339GSE6aMrPJSzMlsV1LmzPdPIypgp5qqh5NfSrKztg==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
+      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.744.0.tgz",
-      "integrity": "sha512-Mnrlh4lRY1gZQnKvN2Lh/5WXcGkzC41NM93mtn2uaqOh+DZLCXCttNCfbUesUvYJLOo3lYaOpiDsjTkPVB1yjw==",
+      "version": "3.996.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
+      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.744.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.744.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.744.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.2",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-retry": "^4.0.4",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.4",
-        "@smithy/util-defaults-mode-node": "^4.0.4",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
+      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/token-providers": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.744.0.tgz",
-      "integrity": "sha512-v/1+lWkDCd60Ei6oyhJqli6mTsPEVepLoSMB50vHUVlJP0fzXu/3FMje90/RzeUoh/VugZQJCEv/NNpuC6wztg==",
+      "version": "3.1015.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1015.0.tgz",
+      "integrity": "sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.743.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-      "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-endpoints": "^3.0.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.744.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.744.0.tgz",
-      "integrity": "sha512-BJURjwIXhNa4heXkLC0+GcL+8wVXaU7JoyW6ckdvp93LL+sVHeR1d5FxXZHQW/pMI4E3gNlKyBqjKaT75tObNQ==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
+      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.744.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -4523,18 +4566,51 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-medialive/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+    "node_modules/@aws-sdk/client-medialive/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
       ],
       "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/@aws-sdk/client-medialive/node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/client-mediapackage": {
       "version": "3.744.0",
@@ -8973,6 +9049,290 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
+      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
+      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
+      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
+      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
+      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.734.0.tgz",
@@ -9527,6 +9887,15 @@
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -16184,12 +16553,12 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16222,15 +16591,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-      "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16238,18 +16608,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-      "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.1.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16257,15 +16629,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-      "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16412,15 +16784,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16443,14 +16815,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-      "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16472,12 +16844,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-      "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16485,9 +16857,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16558,13 +16930,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-      "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16572,18 +16944,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-      "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.5",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16591,45 +16963,34 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-      "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-      "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16637,12 +16998,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16650,14 +17011,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16665,15 +17026,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16681,12 +17042,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16694,12 +17055,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16707,13 +17068,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16721,12 +17082,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16734,24 +17095,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-      "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0"
+        "@smithy/types": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16759,18 +17120,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16778,17 +17139,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-      "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.5",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.2",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16796,9 +17157,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16808,13 +17169,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16822,13 +17183,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16836,9 +17197,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16848,9 +17209,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16860,12 +17221,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16873,9 +17234,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16885,15 +17246,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-      "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16901,17 +17261,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-      "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16919,13 +17279,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-      "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16933,9 +17293,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16945,12 +17305,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16958,13 +17318,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-      "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16972,18 +17332,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-      "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16991,9 +17351,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -17003,12 +17363,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17016,13 +17376,25 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.2.tgz",
-      "integrity": "sha512-piUTHyp2Axx3p/kc2CIJkYSv0BAaheBQmbACZgQSSfWUumWNW+R1lL+H9PDBxKJkvOeEX+hKYEFiwO8xagL8AQ==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
+      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24044,6 +24416,21 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -29769,6 +30156,21 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-dynamodb": "^3.734.0",
         "@aws-sdk/client-iot": "^3.750.0",
         "@aws-sdk/client-iot-data-plane": "^3.744.0",
-        "@aws-sdk/client-medialive": "^3.1017.0",
+        "@aws-sdk/client-medialive": "^3.895.0",
         "@aws-sdk/client-mediapackage": "^3.734.0",
         "@aws-sdk/client-s3": "^3.758.0",
         "@aws-sdk/client-scheduler": "^3.758.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-dynamodb": "^3.734.0",
     "@aws-sdk/client-iot": "^3.750.0",
     "@aws-sdk/client-iot-data-plane": "^3.744.0",
-    "@aws-sdk/client-medialive": "^3.1017.0",
+    "@aws-sdk/client-medialive": "^3.895.0",
     "@aws-sdk/client-mediapackage": "^3.734.0",
     "@aws-sdk/client-s3": "^3.758.0",
     "@aws-sdk/client-scheduler": "^3.758.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-dynamodb": "^3.734.0",
     "@aws-sdk/client-iot": "^3.750.0",
     "@aws-sdk/client-iot-data-plane": "^3.744.0",
-    "@aws-sdk/client-medialive": "^3.734.0",
+    "@aws-sdk/client-medialive": "^3.1017.0",
     "@aws-sdk/client-mediapackage": "^3.734.0",
     "@aws-sdk/client-s3": "^3.758.0",
     "@aws-sdk/client-scheduler": "^3.758.0",


### PR DESCRIPTION
I should update `@aws-sdk/client-medialive` because I use the new version for the smart cropping.
I also have to install the elemental inference lib, but both lib give the same error separately:

When I install a new aws lib or update one all the dynamodb tests failed:

```sh
  
      AWS SDK error wrapper for TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG]: A dynamic import callback was invoked without --experimental-vm-modules
  
        at asSdkError (../../node_modules/@smithy/middleware-retry/dist-cjs/index.js:54:12)
        at ../../node_modules/@smithy/middleware-retry/dist-cjs/index.js:259:29
        at ../../node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:33:22
  
```


