### PR TITLE
fix: medialive channel

### DIFF
--- a/apps/api/template.yaml
+++ b/apps/api/template.yaml
@@ -282,6 +282,12 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'elemental-inference:PutMedia'
+                  - 'elemental-inference:GetMetadata'
+                  - 'elemental-inference:GetFeed'
+                Resource: '*'
   StateMachineLambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/libs/api/api-events/src/useCases/createLiveChannel/createLiveChannel.test.ts
+++ b/libs/api/api-events/src/useCases/createLiveChannel/createLiveChannel.test.ts
@@ -105,8 +105,6 @@ describe('Create live channel use case', () => {
           packageChannelId,
           packageDomainName: 'example.com',
           endpoints: [],
-          verticalPackageChannelId: undefined,
-          verticalPackageDomainName: undefined,
         },
         taskToken,
       },

--- a/libs/api/api-events/src/useCases/createLiveChannel/createLiveChannel.ts
+++ b/libs/api/api-events/src/useCases/createLiveChannel/createLiveChannel.ts
@@ -119,12 +119,12 @@ export class CreateLiveChannelUseCaseImpl implements CreateLiveChannelUseCase {
       output: {
         eventId,
         packageChannelId,
-        verticalPackageChannelId,
         packageDomainName,
-        verticalPackageDomainName,
         liveChannelId: liveChannel.channelId,
         liveChannelArn: liveChannel.channelArn,
         endpoints,
+        ...(verticalPackageChannelId && { verticalPackageChannelId }),
+        ...(verticalPackageDomainName && { verticalPackageDomainName }),
       },
     });
 


### PR DESCRIPTION
- I saw some alerts on medialive concerning the autorization with elemental-inference so I added the missing allowing
- Since `TaskTokensDynamoDBRepository` don't have `removeUndefinedValues: true` we should avoid passing undefined values