### PR TITLE
feat: add separator line

### DIFF
--- a/libs/webui/status-view/src/lib/status-view.tsx
+++ b/libs/webui/status-view/src/lib/status-view.tsx
@@ -366,6 +366,7 @@ export function StatusView() {
               <div className={'w-full md:w-1/2 lg:w-1/3 px-4 pb-4 md:pb-0'}>
                 <Timeline steps={timelineSteps} />
               </div>
+              <div className="hidden md:block w-px bg-base-content/30 mx-4 self-stretch"></div>
               <div className={'flex-grow w-full md:w-1/2 lg:w-2/3 '}>
                 {displayPlayer ? (
                   <>


### PR DESCRIPTION
Add a separator line between the timeline and the video player

<img width="1624" height="920" alt="Screenshot From 2026-04-10 16-43-32" src="https://github.com/user-attachments/assets/b87235ad-aa26-46fa-affc-379116380564" />
